### PR TITLE
Filter URLs only

### DIFF
--- a/gimme_embeds.py
+++ b/gimme_embeds.py
@@ -42,7 +42,7 @@ def text_handler(update, context):
 
 start_handler = CommandHandler("start", start)
 dispatcher.add_handler(start_handler)
-message_handler = MessageHandler(Filters.text, text_handler)
+message_handler = MessageHandler(Filters.entity('url'), text_handler)
 dispatcher.add_handler(message_handler)
 
 updater.start_polling()


### PR DESCRIPTION
Don't pass all kind of texts to the `text_handler` function, just the ones containing URLs.