### PR TITLE
Use `CallbackContext` as an argument for `context`

### DIFF
--- a/gimme_embeds.py
+++ b/gimme_embeds.py
@@ -60,7 +60,7 @@ def edit_text(text):
     return new_url
 
 
-def text_handler(update, message):
+def text_handler(update, context: CallbackContext):
     """
     The primary handler that does all the replacement action through
     the API.


### PR DESCRIPTION
Even though we don't use context methods inside the function,
setting message as one of the function's argument isn't correct.