### PR TITLE
Ignore the links to anything that isn't a tweet or a tiktok

### DIFF
--- a/gimme_embeds.py
+++ b/gimme_embeds.py
@@ -38,6 +38,8 @@ def edit_text(text):
     website URLs with their *x counterparts that support embeds.
     """
 
+    new_url = None
+
     # Setup conditionals.
     # For Twitter
     if re.search(
@@ -63,6 +65,7 @@ def edit_text(text):
         )
         insensitive_tiktok = re.compile(re.escape("tiktok.com"), re.IGNORECASE)
         new_url = insensitive_tiktok.sub("vxtiktok.com", tiktok_url)
+
     return new_url
 
 
@@ -76,16 +79,20 @@ def text_handler(update, context: CallbackContext):
     message = update.message.text
     reply = update.message.reply_text
 
-    """
-    Check if the text contains an hyperlink.
-    If it does, extract the URL and pass it to the edit_text function.
-    If it doesn't, send the entire text to edit_text.
-    """
-    if update.message.entities[0].url is None:
-        reply(edit_text(message))
+    # Check if the text contains an hyperlink and if isn't None.
+    # If it contains an hyperlink, extract the URL and pass it to edit_text.
+    # If it doesn't, send the entire text to edit_text.
+
+    hyperlink_url = update.message.entities[0].url
+
+    if hyperlink_url is None:
+        reply_url = edit_text(message)
+        if reply_url is not None:
+            reply(reply_url)
     else:
-        url = update.message.entities[0].url
-        reply(edit_text(url))
+        reply_url = edit_text(hyperlink_url)
+        if reply_url is not None:
+            reply(reply_url)
 
 
 start_handler = CommandHandler("start", start)

--- a/gimme_embeds.py
+++ b/gimme_embeds.py
@@ -43,13 +43,13 @@ def edit_text(text):
     # Setup conditionals.
     # For Twitter
     if re.search(
-        "(?P<url>twitter.com/(.*?)/[^\s]+)", text, re.IGNORECASE
-    ) and not re.search("(?P<url>xtwitter.com[^\s]+)", text, re.IGNORECASE):
+        r"(?P<url>twitter.com/(.*?)/[^\s]+)", text, re.IGNORECASE
+    ) and not re.search(r"(?P<url>xtwitter.com[^\s]+)", text, re.IGNORECASE):
         # Isolate the Twitter URL.
         twitter_url = str(
-            re.search("(?P<url>([^\s]*?)twitter.com[^\s]+)", text, re.IGNORECASE).group(
-                "url"
-            )
+            re.search(
+                r"(?P<url>([^\s]*?)twitter.com[^\s]+)", text, re.IGNORECASE
+            ).group("url")
         )
         insensitive_twitter = re.compile(re.escape("twitter.com"), re.IGNORECASE)
         new_url = insensitive_twitter.sub("vxtwitter.com", twitter_url)
@@ -57,11 +57,13 @@ def edit_text(text):
 
     # For TikTok
     elif re.search(
-        "(?P<url>tiktok.com/t/[^\s]+)", text, re.IGNORECASE
-    ) and not re.search("(?P<url>xtiktok.com[^\s]+)", text, re.IGNORECASE):
+        r"(?P<url>tiktok.com/t/[^\s]+)", text, re.IGNORECASE
+    ) and not re.search(r"(?P<url>xtiktok.com[^\s]+)", text, re.IGNORECASE):
         # Isolate the tiktok URL.
         tiktok_url = str(
-            re.search("(?P<url>([^\s]*?)tiktok[^\s]+)", text, re.IGNORECASE).group("url")
+            re.search(r"(?P<url>([^\s]*?)tiktok[^\s]+)", text, re.IGNORECASE).group(
+                "url"
+            )
         )
         insensitive_tiktok = re.compile(re.escape("tiktok.com"), re.IGNORECASE)
         new_url = insensitive_tiktok.sub("vxtiktok.com", tiktok_url)

--- a/gimme_embeds.py
+++ b/gimme_embeds.py
@@ -90,7 +90,9 @@ def text_handler(update, context: CallbackContext):
 
 start_handler = CommandHandler("start", start)
 dispatcher.add_handler(start_handler)
-message_handler = MessageHandler(Filters.text, text_handler)
+message_handler = MessageHandler(
+    (Filters.entity("url") | Filters.entity("text_link")), text_handler
+)
 dispatcher.add_handler(message_handler)
 
 updater.start_polling()

--- a/gimme_embeds.py
+++ b/gimme_embeds.py
@@ -35,29 +35,31 @@ def start(update: Update, context: CallbackContext):
 def edit_text(text):
     """
     This function edits the text of the message, by replacing some
-    website URLs with their vx counterparts that support embeds.
+    website URLs with their *x counterparts that support embeds.
     """
 
     # Setup conditionals.
     # For Twitter
-    if re.search("(?P<url>twitter.com[^\s]+)", text, re.IGNORECASE) and not re.search(
-        "(?P<url>xtwitter.com[^\s]+)", text, re.IGNORECASE
-    ):
+    if re.search(
+        "(?P<url>twitter.com/(.*?)/[^\s]+)", text, re.IGNORECASE
+    ) and not re.search("(?P<url>xtwitter.com[^\s]+)", text, re.IGNORECASE):
         # Isolate the Twitter URL.
         twitter_url = str(
-            re.search("(?P<url>twitter.com[^\s]+)", text, re.IGNORECASE).group("url")
+            re.search("(?P<url>([^\s]*?)twitter.com[^\s]+)", text, re.IGNORECASE).group(
+                "url"
+            )
         )
         insensitive_twitter = re.compile(re.escape("twitter.com"), re.IGNORECASE)
         new_url = insensitive_twitter.sub("vxtwitter.com", twitter_url)
-        new_url = new_url.split("?")[0] # Remove trackers
+        new_url = new_url.split("?")[0]  # Remove trackers
 
     # For TikTok
-    elif re.search("(?P<url>tiktok.com[^\s]+)", text, re.IGNORECASE) and not re.search(
-        "(?P<url>xtiktok.com[^\s]+)", text, re.IGNORECASE
-    ):
+    elif re.search(
+        "(?P<url>tiktok.com/t/[^\s]+)", text, re.IGNORECASE
+    ) and not re.search("(?P<url>xtiktok.com[^\s]+)", text, re.IGNORECASE):
         # Isolate the tiktok URL.
         tiktok_url = str(
-            re.search("(?P<url>tiktok[^\s]+)", text, re.IGNORECASE).group("url")
+            re.search("(?P<url>([^\s]*?)tiktok[^\s]+)", text, re.IGNORECASE).group("url")
         )
         insensitive_tiktok = re.compile(re.escape("tiktok.com"), re.IGNORECASE)
         new_url = insensitive_tiktok.sub("vxtiktok.com", tiktok_url)


### PR DESCRIPTION
There isn't any need to show the preview of the base URL or a (Twitter) profile.

Let's convert only the URLs that point to actual Tweets or TikTok videos.